### PR TITLE
Move ui build into docker.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,15 @@ RUN git clone https://github.com/oMaN-Rod/palworld-save-tools.git -b v0.4.11
 
 FROM node:23 AS ui_builder
 
+ARG PUBLIC_WS_URL=127.0.0.1:5174/ws
+
 COPY . /app
 WORKDIR /app/ui
-RUN rm -rf .svelte-kit 
-RUN echo "PUBLIC_WS_URL=127.0.0.1:5174/ws" >.env
-RUN echo "PUBLIC_DESKTOP_MODE=false" >>.env
-RUN npm install
-RUN npm run build
+RUN rm -rf .svelte-kit; \
+    echo "PUBLIC_WS_URL=${PUBLIC_WS_URL}" >.env; \
+    echo "PUBLIC_DESKTOP_MODE=false" >>.env; \
+    npm install; \
+    npm run build
 
 FROM python:3.12
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,17 @@
-FROM python:3.12 as builder
+FROM python:3.12 AS builder
 
 # Clone the temp palworld-save-tools repo until it gets updated
 RUN git clone https://github.com/oMaN-Rod/palworld-save-tools.git -b v0.4.11
+
+FROM node:23 AS ui_builder
+
+COPY . /app
+WORKDIR /app/ui
+RUN rm -rf .svelte-kit 
+RUN echo "PUBLIC_WS_URL=127.0.0.1:5174/ws" >.env
+RUN echo "PUBLIC_DESKTOP_MODE=false" >>.env
+RUN npm install
+RUN npm run build
 
 FROM python:3.12
 
@@ -19,7 +29,7 @@ RUN pip install -e palworld-save-tools
 # Copy necessary files and directories
 COPY psp.py .
 COPY palworld_save_pal ./palworld_save_pal
-COPY ui_build ./ui
+COPY --from=ui_builder /app/ui_build ./ui
 COPY data ./data
 
 CMD ["python", "psp.py"]

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -8,52 +8,6 @@ set -e
 # Navigate to the script's directory
 cd "$(dirname "$0")"
 
-# Get the IP address
-ip_address=$(hostname -I | awk '{print $1}')
-
-# Create or update the .env file with PUBLIC_WS_URL
-echo "PUBLIC_WS_URL=${ip_address}:5174/ws" >./ui/.env
-echo "PUBLIC_DESKTOP_MODE=false" >>./ui/.env
-
-# Navigate to the ui directory
-cd ./ui
-
-# Remove .svelte-kit directory if it exists
-if [ -d ".svelte-kit" ]; then
-    echo "Removing .svelte-kit directory..."
-    rm -rf .svelte-kit
-fi
-
-# Function to check if a command exists
-command_exists() {
-    command -v "$1" >/dev/null 2>&1
-}
-
-# Determine which package manager to use
-if command_exists bun; then
-    package_manager="bun"
-elif command_exists npm; then
-    package_manager="npm"
-elif command_exists yarn; then
-    package_manager="yarn"
-else
-    echo "Error: No suitable package manager found. Please install Bun, npm, or Yarn." >&2
-    exit 1
-fi
-
-echo "Using $package_manager as the package manager."
-
-# Install dependencies
-echo "Installing dependencies..."
-$package_manager install
-
-# Build the frontend
-echo "Building the frontend..."
-$package_manager run build
-
-# Navigate back to the root directory
-cd ..
-
 # Run docker-compose up --build -d
 echo "Starting Docker Compose..."
 docker compose up --build -d

--- a/data/json/settings.json
+++ b/data/json/settings.json
@@ -1,0 +1,3 @@
+{
+  "language": "en"
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,6 @@ services:
     ports:
       - "5174:5174"
     volumes:
-      - ./ui_build:/app/ui
       - ./data:/app/data
       - ./palworld_save_pal:/app/palworld_save_pal
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,9 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      args:
+      # Change this to the URL of your public server
+      - PUBLIC_WS_URL=127.0.0.1:5174/ws
     ports:
       - "5174:5174"
     volumes:


### PR DESCRIPTION
Build the ui component in a node docker to avoid configure the host building environment(node version/package manager, etc). 

The docker version can be build with ```docker compose up --build -d```

UI accessible at  ```127.0.0.1:5174```.