### PR TITLE
Active Skill Changes

### DIFF
--- a/data/json/pals.json
+++ b/data/json/pals.json
@@ -18994,7 +18994,8 @@
     "size": "None",
     "rarity": 1,
     "element_types": [
-      "Dark"
+      "Dark",
+      "Water"
     ],
     "genus_category": "Unknown",
     "weapon": "None",

--- a/ui/src/lib/components/badges/active-skill-badge/ActiveSkillBadge.svelte
+++ b/ui/src/lib/components/badges/active-skill-badge/ActiveSkillBadge.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { activeSkillsData, elementsData } from '$lib/data';
 	import { ASSET_DATA_PATH } from '$lib/constants';
-	import { getModalState } from '$states';
+	import { getAppState, getModalState } from '$states';
 	import { SkillSelectModal } from '$components/modals';
 	import { Tooltip } from '$components/ui';
 	import { TimerReset } from 'lucide-svelte';
@@ -18,6 +18,7 @@
 		onSkillUpdate?: (newSkill: string, oldSkill: string) => void;
 	}>();
 
+	const appState = getAppState();
 	const modal = getModalState();
 
 	let { activeSkill, element, elementIconWhite, elementIcon } = $derived.by(() => {
@@ -41,7 +42,8 @@
 			type: 'Active',
 			value: skill,
 			title: 'Select Active Skill',
-			palCharacterId
+			palCharacterId,
+			pal: appState.selectedPal
 		});
 		if (!result) return;
 		onSkillUpdate(result, skill);

--- a/ui/src/lib/components/modals/learned-skill-select/LearnedSkillSelectModal.svelte
+++ b/ui/src/lib/components/modals/learned-skill-select/LearnedSkillSelectModal.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 	import { Card, Tooltip, Combobox, List } from '$components/ui';
 	import type { ActiveSkill } from '$types';
-	import { Plus, Save, X, Trash, TimerReset, Delete } from 'lucide-svelte';
-	import { activeSkillsData, elementsData } from '$lib/data';
+	import { Plus, Save, X, Trash, TimerReset, Delete, BicepsFlexed, Brain } from 'lucide-svelte';
+	import { activeSkillsData, elementsData, palsData } from '$lib/data';
 	import { ASSET_DATA_PATH } from '$lib/constants';
 	import { assetLoader } from '$utils';
 	import { staticIcons } from '$types/icons';
@@ -34,11 +34,34 @@
 		return assetLoader.loadImage(`${ASSET_DATA_PATH}/img/${element.icon}.png`);
 	}
 
+	function handleUnlearnedSkills() {
+		let unlearnedSkills = selectOptions.filter(uskill => !learnedSkills.includes(uskill.value))
+		return unlearnedSkills
+	}
+
 	function handleAddSkill() {
 		if (selectedSkill && !learnedSkills.includes(selectedSkill)) {
 			learnedSkills = [...learnedSkills, selectedSkill];
 			selectedSkill = '';
 		}
+	}
+
+	function handleLearnType() {
+		let palData = Object.entries(palsData.pals)
+			.find(([key, _]) => key.includes(pal.character_key))?.[1] || null;
+		let elementType = activeSkills.filter(item => palData?.element_types.some(type => item.details.element === type))
+		let elementSkills = elementType.map(item => item.id)
+			.filter(key => !key.includes('Unique'))
+		learnedSkills = [
+			...learnedSkills,
+			...elementSkills.filter(skill => !learnedSkills.includes(skill))
+		];
+	}
+
+	function handleLearnAll() {
+		learnedSkills = selectOptions
+			.filter(item => !item.value.includes('Unique'))
+			.map(item => item.value);
 	}
 
 	function handleRemoveSkill(skill: string) {
@@ -61,7 +84,7 @@
 <Card class="min-w-[calc(100vw/3)]">
 	<h3 class="h3">Edit Learned Skills</h3>
 	<div class="mt-4 flex items-center space-x-2">
-		<Combobox options={selectOptions} bind:value={selectedSkill}>
+		<Combobox options={handleUnlearnedSkills()} bind:value={selectedSkill}>
 			{#snippet selectOption(option)}
 				{#await getActiveSkillIcon(option.value) then icon}
 					{@const activeSkill = activeSkills.find((s) => s.id === option.value)}
@@ -143,6 +166,22 @@
 	</div>
 
 	<div class="mt-4 flex justify-end space-x-2">
+		<Tooltip position="bottom">
+			<button class="btn hover:bg-secondary-500/25 px-2" onclick={handleLearnType}>
+				<Brain />
+			</button>
+			{#snippet popup()}
+				<span>Learn All Skills<br>Matching Pal Type</span>
+			{/snippet}
+		</Tooltip>
+		<Tooltip position="bottom">
+			<button class="btn hover:bg-secondary-500/25 px-2" onclick={handleLearnAll}>
+				<BicepsFlexed />
+			</button>
+			{#snippet popup()}
+				<span>Learn All Skills</span>
+			{/snippet}
+		</Tooltip>
 		<Tooltip position="bottom">
 			<button class="btn hover:bg-secondary-500/25 px-2" onclick={handleClear}>
 				<Delete />

--- a/ui/src/lib/components/modals/learned-skill-select/LearnedSkillSelectModal.svelte
+++ b/ui/src/lib/components/modals/learned-skill-select/LearnedSkillSelectModal.svelte
@@ -36,7 +36,6 @@
 		return assetLoader.loadImage(`${ASSET_DATA_PATH}/img/${element.icon}.png`);
 	}
 
-
 	function handleAddSkill() {
 		if (selectedSkill && !learnedSkills.includes(selectedSkill)) {
 			learnedSkills = [...learnedSkills, selectedSkill];
@@ -46,7 +45,7 @@
 
 	function handleLearnType() {
 		let palData = Object.entries(palsData.pals)
-			.find(([key, _]) => key.includes(pal.character_key))?.[1] || null;
+			.find(([key, _]) => key === pal.character_key)?.[1] || null;
 		let elementType = activeSkills.filter(item => palData?.element_types.some(type => item.details.element === type))
 		let elementSkills = elementType.map(item => item.id)
 			.filter(key => !key.includes('Unique'))

--- a/ui/src/lib/components/modals/skill-select/SkillSelectModal.svelte
+++ b/ui/src/lib/components/modals/skill-select/SkillSelectModal.svelte
@@ -17,12 +17,14 @@
 		value = $bindable(''),
 		type = 'Active',
 		palCharacterId = '',
+		pal,
 		closeModal
 	} = $props<{
 		title?: string;
 		value?: string;
 		type?: SkillType;
 		palCharacterId?: string;
+		pal: any;
 		closeModal: (value: any) => void;
 	}>();
 
@@ -38,6 +40,8 @@
 					}
 					return false;
 				})
+				.filter((aSkill) => !Object.values(pal.active_skills)
+					.some((skill) => skill === aSkill.id))
 				.sort((a, b) => a.details.element.localeCompare(b.details.element))
 				.map((s) => ({
 					value: s.id,
@@ -101,9 +105,9 @@
 			(s) => s.id === option.value
 		)}
 		<div class="grid grid-cols-[auto_1fr_auto] items-center gap-2">
-			<img src={icon} alt={option.label} class="h-6 w-6" />
+			<img src={icon} alt={activeSkill?.localized_name} class="h-6 w-6" />
 			<div class="mr-0.5 flex flex-col">
-				<span class="truncate">{option.label}</span>
+				<span class="truncate">{activeSkill?.localized_name}</span>
 				<span class="text-xs">{activeSkill?.description}</span>
 			</div>
 			<div class="flex flex-col">


### PR DESCRIPTION
Replacement for [original PR](https://github.com/oMaN-Rod/palworld-save-pal/pull/88)

- Updated active skill assign to not include a skill that is already assigned to active skills
-- I tested having multiple of the same skill on a pal in game and when using one, they all go on cooldown
- Added the ability to learn all non-unique skills
- Added the ability to dynamically assign all non-unique skills to a Pal that match their typing. Support for multi-typing.
- Changed how the Combobox works to only show skills that are not currently learned by the Pal
- Fixed learned skill list showing (thanks O)
- Added water element to Killamari