### PR TITLE
Fix Anubis Issue, Default Player, Add All

### DIFF
--- a/palworld_save_pal/game/pal.py
+++ b/palworld_save_pal/game/pal.py
@@ -208,7 +208,7 @@ class Pal(BaseModel):
     @computed_field
     def is_boss(self) -> bool:
         self._is_boss = False
-        if self.character_id.startswith("BOSS_") and not self.is_lucky:
+        if self.character_id.upper().startswith("BOSS_") and not self.is_lucky:
             self._is_boss = True
         return self._is_boss
 

--- a/ui/src/lib/components/pal-header/PalHeader.svelte
+++ b/ui/src/lib/components/pal-header/PalHeader.svelte
@@ -194,6 +194,7 @@
 	}
 
 	function formatBossCharacterId() {
+		pal.character_id = pal.character_id.replace('Boss_', 'BOSS_');
 		if (pal && (pal.is_boss || pal.is_lucky) && !pal.character_id.startsWith('BOSS_')) {
 			pal.character_id = `BOSS_${pal.character_id}`;
 		} else if (pal && !pal.is_boss && !pal.is_lucky && pal.character_id.startsWith('BOSS_')) {

--- a/ui/src/lib/components/player-list/PlayerList.svelte
+++ b/ui/src/lib/components/player-list/PlayerList.svelte
@@ -17,6 +17,12 @@
 			label: player.nickname || `Player ${uid}`
 		}))
 	);
+
+	if (Object.keys(appState.players).length === 1) {
+        const singlePlayerId = Object.keys(appState.players)[0];
+        selected = singlePlayerId;
+        onselect(appState.players[singlePlayerId]);
+    }
 </script>
 
 <div class="w-full" {...additionalProps}>

--- a/ui/src/routes/edit/components/palbox/PalBox.svelte
+++ b/ui/src/routes/edit/components/palbox/PalBox.svelte
@@ -673,7 +673,6 @@
 		if (!appState.selectedPlayer) return;
 
 		const containerId = appState.selectedPlayer.pal_box_id;
-		let idCounter = 0;
 
 		const exclude = ['PREDATOR_', 'RAID_', 'GYM_', 'SUMMON_', '_Oilrig'];
 
@@ -689,7 +688,6 @@
 				character_id: key,
 				nickname,
 				container_id: containerId,
-				storage_slot: idCounter++
 			});
 		}
 


### PR DESCRIPTION
Apparently Anubis is the only pal in the game files that is appended with "Boss_" and not "BOSS_"
This was causing PSP not to recognize Anubis as boss, and also made the ID "BOSS_Boss_" in which broke the asset loading for Anubis in game. I don't know if this is exclusive to different language/region of steam, because my game prefixes it with "BOSS_". So it's strange. But nonetheless, the changes shouldn't hurt anything.

Added checking for this and to replace lowercase instances with upper. 

Also added pre-populating player if only 1 player is found in the save.

![image](https://github.com/user-attachments/assets/ed2af3a2-36fc-46d5-b449-3097a1d26844)