### PR TITLE
Replace editable Combobox with read-only Select for player selection

### DIFF
--- a/ui/src/lib/components/player-list/PlayerList.svelte
+++ b/ui/src/lib/components/player-list/PlayerList.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import type { Player } from '$types';
-	import { Combobox } from '$components/ui';
+	import { Select } from '$components/ui';
 	import { getAppState } from '$states';
 
 	let appState = getAppState();
@@ -26,7 +26,7 @@
 </script>
 
 <div class="w-full" {...additionalProps}>
-	<Combobox
+	<Select
 		value={selected}
 		options={selectOptions}
 		placeholder="Select Player"


### PR DESCRIPTION
## Problem
The player selection field currently uses a Combobox component, which allows users to type and edit player usernames. Since usernames come directly from the save file and should not be modified, this creates confusion.

## Solution
Replaced Combobox with Select component to make it a read-only dropdown. Users can now only select from existing players in the list.

## Changes
- Updated PlayerList.svelte to use Select instead of Combobox
- Improves UX by always showing the dropdown on click