### PR TITLE
Add auto-load on startup and reload save button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,4 @@ ENV/
 backups/
 data/json/settings.json
 .claude/
+docker-compose.yml.backup

--- a/AUTO-LOAD-FEATURE.md
+++ b/AUTO-LOAD-FEATURE.md
@@ -1,0 +1,122 @@
+# Auto-Load & Reload Feature
+
+This feature allows Palworld Save Pal to automatically load save files from a mounted directory at startup, and provides a "Reload Save" button to refresh the save without restarting the container.
+
+## ✨ Features Added
+
+1. **Auto-load on startup** - Automatically reads `.sav` files from mounted directory
+2. **Reload Save button** - Green button in the UI to refresh saves live (only visible when a save is auto-loaded)
+3. **No unzipping needed** - Reads raw `.sav` files directly, bypassing zip extraction
+
+## 🚀 How It Works
+
+### Startup Flow
+```
+Container starts → Check /app/saves → Find .sav files → Load directly → Ready!
+```
+
+### Reload Flow
+```
+Click "Reload Save" button → Re-read /app/saves → Load fresh data → UI updates
+```
+
+## 📝 Configuration
+
+### 1. Mount Your Save Directory
+
+Edit `docker-compose.yml`:
+```yaml
+volumes:
+  - /path/to/your/SaveGames/0/YOUR-WORLD-ID:/app/saves:ro
+environment:
+  - SAVE_MOUNT_PATH=/app/saves
+```
+
+**Example:**
+```yaml
+volumes:
+  - /home/paul/.gamedata/palworld/Pal/Saved/SaveGames/0/E78D2AA4834049EF90A165AE9CBB433D:/app/saves:ro
+environment:
+  - SAVE_MOUNT_PATH=/app/saves
+```
+
+### 2. Directory Structure Expected
+
+Your mounted directory should contain:
+```
+/app/saves/
+├── Level.sav          (required)
+├── LevelMeta.sav      (optional)
+└── Players/           (required)
+    ├── PLAYER-UUID-1.sav
+    ├── PLAYER-UUID-2.sav
+    └── ...
+```
+
+### 3. Start Container
+
+```bash
+docker compose up --build -d
+```
+
+Check logs to verify auto-load:
+```bash
+docker logs palworld-save-pal-backend-1
+```
+
+Look for:
+```
+✅ Auto-load successful! Save file ready.
+```
+
+## 🔄 Using the Reload Feature
+
+1. The **"Reload Save"** button appears in the top-right (green, next to Discord button)
+2. Only visible when `appState.saveFile.local === true` (auto-loaded saves)
+3. Click it to reload fresh data from the mounted directory
+4. Shows loading progress with messages
+5. Updates all players, guilds, and pals automatically
+
+## 🛠️ Files Modified
+
+- `palworld_save_pal/utils/auto_loader.py` - New: Auto-load logic
+- `palworld_save_pal/ws/handlers/save_file_handler.py` - Added: `reload_mounted_save_handler`
+- `palworld_save_pal/ws/messages.py` - Added: `RELOAD_MOUNTED_SAVE` message type
+- `palworld_save_pal/ws/handlers/bootstrap.py` - Registered reload handler
+- `psp.py` - Added startup event to auto-load saves
+- `docker-compose.yml` - Configured volume mount and env var
+- `ui/src/lib/types/ws.ts` - Added message type
+- `ui/src/routes/edit/+layout.svelte` - Added Reload Save button
+
+## 📊 Data Storage
+
+**Important:** The save files are parsed into memory. The `data/` directory contains:
+- SQLite database (presets, settings, UPS collections)
+- Static reference JSON files (items, pals, skills, etc.)
+- **NOT your actual save data** - that stays in memory
+
+## 🔍 Troubleshooting
+
+### No auto-load on startup
+```bash
+# Check if mount path exists
+docker exec palworld-save-pal-backend-1 ls -la /app/saves
+
+# Check environment variable
+docker exec palworld-save-pal-backend-1 env | grep SAVE_MOUNT_PATH
+```
+
+### Reload button not showing
+- Only appears when save is auto-loaded (local=true)
+- Check if you manually uploaded a zip instead
+
+### Save not updating after reload
+- Ensure mount is NOT read-only if Palworld is writing to it
+- Or remount after Palworld updates the files
+
+## 💡 Benefits
+
+- **No manual upload needed** - Just start the container
+- **Live updates** - Reload without restarting
+- **Read-only safe** - Mount with `:ro` flag to prevent accidental writes
+- **Faster workflow** - Skip zip/unzip entirely

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,9 @@ services:
     volumes:
       - ./data:/app/data
       - ./palworld_save_pal:/app/palworld_save_pal
+      # Uncomment and adjust the path below to auto-load your save files
+      # - /path/to/your/SaveGames/0/YOUR-WORLD-ID:/app/saves:ro  
     environment:
       - PORT=5174
+      - SAVE_MOUNT_PATH=/app/saves  # Path where saves are mounted (auto-load enabled)
     command: python psp.py

--- a/palworld_save_pal/utils/auto_loader.py
+++ b/palworld_save_pal/utils/auto_loader.py
@@ -1,0 +1,116 @@
+"""Auto-loader for mounted save directories.
+
+This module handles loading Palworld save files directly from a mounted directory,
+bypassing the normal zip upload process. It reads raw .sav files and prepares them
+for processing - NO UNZIPPING REQUIRED since the files are already in .sav format.
+
+Flow comparison:
+- Normal: User uploads ZIP → unzip → extract .sav bytes → process
+- Auto-load: Read .sav files directly → process (skips unzip entirely)
+"""
+import os
+import zipfile
+from pathlib import Path
+from typing import Dict, Optional
+import uuid
+from palworld_save_pal.utils.logging_config import create_logger
+
+logger = create_logger(__name__)
+
+
+def check_mounted_saves(mount_path: str = "/app/saves") -> Optional[Dict]:
+    """
+    Check if there's a mounted save directory and prepare it for loading.
+    
+    NOTE: This reads RAW .sav files directly - no zip extraction needed!
+    The mounted directory should contain Level.sav, LevelMeta.sav, and Players/ folder.
+    
+    Args:
+        mount_path: Path where saves are mounted in the container
+        
+    Returns:
+        Dict with save data ready for processing, or None if no valid saves found
+    """
+    if not os.path.exists(mount_path):
+        logger.info(f"No mounted save directory found at {mount_path}")
+        return None
+    
+    logger.info(f"Found mounted save directory at {mount_path}")
+    
+    # Check for Level.sav (required file)
+    level_sav_path = Path(mount_path) / "Level.sav"
+    if not level_sav_path.exists():
+        logger.warning(f"No Level.sav found in {mount_path}")
+        return None
+    
+    # Check for LevelMeta.sav (optional but recommended)
+    level_meta_path = Path(mount_path) / "LevelMeta.sav"
+    level_meta_data = None
+    if level_meta_path.exists():
+        with open(level_meta_path, "rb") as f:
+            level_meta_data = f.read()
+        logger.info("Found LevelMeta.sav")
+    
+    # Read Level.sav
+    with open(level_sav_path, "rb") as f:
+        level_sav_data = f.read()
+    logger.info(f"Loaded Level.sav ({len(level_sav_data)} bytes)")
+    
+    # Check for Players directory
+    players_dir = Path(mount_path) / "Players"
+    if not players_dir.exists() or not players_dir.is_dir():
+        logger.warning(f"No Players directory found in {mount_path}")
+        return None
+    
+    # Load player saves
+    player_saves: Dict[uuid.UUID, Dict[str, bytes]] = {}
+    for player_file in players_dir.glob("*.sav"):
+        player_id = player_file.stem  # filename without extension
+        
+        # Handle DPS files
+        dps = False
+        if "_dps" in player_id:
+            player_id = player_id.replace("_dps", "")
+            dps = True
+        
+        try:
+            player_uuid = uuid.UUID(player_id)
+        except ValueError:
+            logger.warning(f"Skipping invalid player file: {player_file.name}")
+            continue
+        
+        if player_uuid not in player_saves:
+            player_saves[player_uuid] = {}
+        
+        save_type = "dps" if dps else "sav"
+        with open(player_file, "rb") as f:
+            player_saves[player_uuid][save_type] = f.read()
+        
+        logger.info(f"Loaded player {player_uuid} ({save_type})")
+    
+    if not player_saves:
+        logger.warning("No valid player save files found")
+        return None
+    
+    # Use the mount path name as save_id, or a default
+    save_id = Path(mount_path).name
+    if save_id == "saves":
+        save_id = "0"  # Default to server ID "0"
+    
+    logger.info(f"Successfully prepared auto-load data with {len(player_saves)} players")
+    
+    return {
+        "save_id": save_id,
+        "level_sav": level_sav_data,
+        "level_meta": level_meta_data,
+        "player_saves": player_saves,
+    }
+
+
+def create_watch_mode(mount_path: str = "/app/saves", callback=None):
+    """
+    Optional: Watch the mounted directory for changes and trigger reload.
+    This is more advanced and requires file watching libraries.
+    """
+    # TODO: Implement file watching if needed
+    pass

--- a/palworld_save_pal/ws/handlers/app_state_handler.py
+++ b/palworld_save_pal/ws/handlers/app_state_handler.py
@@ -25,6 +25,7 @@ async def sync_app_state_handler(_: SyncAppStateMessage, ws: WebSocket):
         "world_name": save_file.world_name,
         "type": app_state.save_type.name.lower(),
         "size": save_file.size,
+        "local": app_state.local,
     }
 
     response = build_response(MessageType.LOADED_SAVE_FILES, data)

--- a/palworld_save_pal/ws/handlers/bootstrap.py
+++ b/palworld_save_pal/ws/handlers/bootstrap.py
@@ -120,6 +120,14 @@ def bootstrap(dispatcher: "MessageDispatcher"):
     )
 
     dispatcher.register_handler(
+        MessageType.RELOAD_MOUNTED_SAVE.value,
+        {
+            "message_class": BaseMessage,
+            "handler_func": save_file_handler.reload_mounted_save_handler,
+        },
+    )
+
+    dispatcher.register_handler(
         MessageType.UPDATE_SAVE_FILE.value,
         {
             "message_class": UpdateSaveFileMessage,

--- a/palworld_save_pal/ws/messages.py
+++ b/palworld_save_pal/ws/messages.py
@@ -93,6 +93,7 @@ class MessageType(str, Enum):
     LOADED_SAVE_FILES = "loaded_save_files"
     LOAD_ZIP_FILE = "load_zip_file"
     NO_FILE_SELECTED = "no_file_selected"
+    RELOAD_MOUNTED_SAVE = "reload_mounted_save"
     SAVE_MODDED_SAVE = "save_modded_save"
     SELECT_GAMEPASS_SAVE = "select_gamepass_save"
     SELECT_SAVE = "select_save"

--- a/ui/src/lib/types/game.ts
+++ b/ui/src/lib/types/game.ts
@@ -182,7 +182,7 @@ export type GuildDTO = {
 
 export type SaveFileType = 'gamepass' | 'steam';
 
-export type SaveFile = { name: string; type: SaveFileType; world_name?: string; size?: number };
+export type SaveFile = { name: string; type: SaveFileType; world_name?: string; size?: number; local?: boolean };
 export interface DynamicItem {
 	local_id: string;
 	durability: number;

--- a/ui/src/lib/types/ws.ts
+++ b/ui/src/lib/types/ws.ts
@@ -18,6 +18,7 @@ export enum MessageType {
 	GET_PAL_DETAILS = 'get_pal_details',
 	LOAD_ZIP_FILE = 'load_zip_file',
 	PROGRESS_MESSAGE = 'progress_message',
+	RELOAD_MOUNTED_SAVE = 'reload_mounted_save',
 	SYNC_APP_STATE = 'sync_app_state',
 	UPDATE_SAVE_FILE = 'update_save_file',
 	GET_PRESETS = 'get_presets',

--- a/ui/src/lib/ws/handlers/saveFileHandler.ts
+++ b/ui/src/lib/ws/handlers/saveFileHandler.ts
@@ -15,10 +15,10 @@ export const loadedSaveFilesHandler: WSMessageHandler = {
 	type: MessageType.LOADED_SAVE_FILES,
 	async handle(data) {
 		const appState = getAppState();
-		const { level, players, world_name, size, type } = data;
-		console.log('Loaded save files', level, players);
+		const { level, players, world_name, size, type, local } = data;
+		console.log('Loaded save files', level, players, 'local:', local);
 		appState.resetState();
-		appState.saveFile = { name: level, world_name, type };
+		appState.saveFile = { name: level, world_name, type, local };
 		appState.playerSaveFiles = players.map((p: any) => ({ name: p }));
 	}
 };

--- a/ui/src/routes/edit/+layout.svelte
+++ b/ui/src/routes/edit/+layout.svelte
@@ -4,8 +4,9 @@
 	import { goto } from '$app/navigation';
 	import { MessageType, type Player } from '$types';
 	import { KeyboardShortcut, Tooltip } from '$components/ui';
-	import { send } from '$utils/websocketUtils';
+	import { send, pushProgressMessage } from '$utils/websocketUtils';
 	import Nuke from '$components/ui/icons/Nuke.svelte';
+	import { RefreshCw } from 'lucide-svelte';
 	
 	const { children } = $props();
 
@@ -70,6 +71,12 @@
 		}
 	}
 
+	async function handleReloadSave() {
+		await goto('/loading');
+		pushProgressMessage('Reloading save from mounted directory... 🔄');
+		send(MessageType.RELOAD_MOUNTED_SAVE);
+	}
+
 	async function handleOnSelectPlayer(player: Player) {
 		appState.selectedPlayer = player;
 		goto('/edit/player');
@@ -124,13 +131,24 @@
 				<KeyboardShortcut text="Pal" key="P" href="/edit/pal"/>
 				{/if}
 			</div>
-			<a
-				href="https://discord.gg/YWZFPy9G8J"
-				target="_blank"
-				rel="noopener noreferrer"
-				class="mr-2 inline-flex rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white hover:bg-indigo-700 {appState.saveFile
-					? ''
-					: 'mt-3'}"
+			<div class="flex gap-2">
+				{#if appState.saveFile?.local}
+					<button
+						onclick={handleReloadSave}
+						class="inline-flex rounded-md bg-green-600 px-3 py-2 text-sm font-medium text-white hover:bg-green-700"
+						title="Reload save from mounted directory"
+					>
+						<RefreshCw size={20} class="mr-2" />
+						Reload Save
+					</button>
+				{/if}
+				<a
+					href="https://discord.gg/YWZFPy9G8J"
+					target="_blank"
+					rel="noopener noreferrer"
+					class="inline-flex rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white hover:bg-indigo-700 {appState.saveFile
+						? ''
+						: 'mt-3'}"
 			>
 				<svg
 					class="mr-2 h-5 w-5"
@@ -144,6 +162,7 @@
 				</svg>
 				Support
 			</a>
+			</div>
 		</div>
 		<div class="overflow-y-auto">
 			{@render children()}


### PR DESCRIPTION
# Add Auto-Load and Reload Save Features

## Summary
Adds automatic save file loading on startup and a live reload button to refresh saves without restarting the container.

## Features
- **Auto-load on startup**: Reads raw `.sav` files from mounted directory, bypassing zip upload
- **Reload Save button**: Green button in UI to refresh save data without restart (only shown for auto-loaded saves)
- **Configuration**: Mount your save directory and set `SAVE_MOUNT_PATH` env var

## Usage
```yaml
volumes:
  - /path/to/SaveGames/0/YOUR-WORLD-ID:/app/saves:ro
environment:
  - SAVE_MOUNT_PATH=/app/saves