### PR TITLE
chore: added missing python-multipart for docker builds

### DIFF
--- a/requirements-docker.txt
+++ b/requirements-docker.txt
@@ -35,3 +35,4 @@ uvicorn==0.32.1
 websockets==15.0.1
 zstandard==0.23.0
 git+https://github.com/oMaN-Rod/palworld-save-tools.git@main
+python-multipart


### PR DESCRIPTION
The python-multipart dependency is missing in the docker builds. This fixes the issue, that it was not starting for me on linux. In theory should also fix mac/windows docker setups