### PR TITLE
Fix: write player save filenames with uppercase GUID (Linux dedicated server character loss)

### DIFF
--- a/palworld_save_pal/game/mixins/serialization.py
+++ b/palworld_save_pal/game/mixins/serialization.py
@@ -208,7 +208,10 @@ class SerializationMixin:
                     player_files.sav.write(CUSTOM_PROPERTIES),
                     0x31,
                 )
-                uid = str(uid).replace("-", "")
+                # GUID hex must be uppercase: Palworld reads player saves by
+                # the uppercase filename, so a lowercase name orphans the record
+                # on case-sensitive filesystems (Linux dedicated servers).
+                uid = str(uid).replace("-", "").upper()
                 atomic_write(os.path.join(output_path, f"{uid}.sav"), sav_file)
                 if player_files.dps:
                     dps_sav_file = compress_gvas_to_sav(

--- a/tests/game/test_save_manager.py
+++ b/tests/game/test_save_manager.py
@@ -135,3 +135,32 @@ class TestSaveManagerWorldName:
         sm = SaveManager()
         with pytest.raises(ValueError, match="No LevelMeta"):
             sm.set_world_name("Test")
+
+
+class TestSaveManagerPlayerSavOutput:
+    def test_player_sav_filenames_are_uppercase(
+        self, event_loop, fresh_save_manager, tmp_path
+    ):
+        # Load a player so its GVAS files are populated for serialization.
+        event_loop.run_until_complete(
+            fresh_save_manager.load_player_on_demand(PLAYER_O_UID, ws_callback=_noop)
+        )
+        players_dir = tmp_path / "Players"
+        players_dir.mkdir()
+        fresh_save_manager.to_player_sav_files(str(players_dir))
+
+        written = sorted(p.name for p in players_dir.glob("*.sav"))
+        assert written, "no player .sav files were written"
+
+        # Palworld stores player saves with the GUID hex in UPPERCASE. On a
+        # case-sensitive filesystem (Linux dedicated server) a lowercase name
+        # orphans the player record, so the game loads a blank character.
+        for name in written:
+            hex_part = name[: -len(".sav")].replace("_dps", "")
+            assert hex_part == hex_part.upper(), (
+                f"player save filename must be uppercase, got {name!r}"
+            )
+
+        # The loaded player's file must exist under its canonical uppercase name.
+        expected = PLAYER_O_UID.hex.upper() + ".sav"
+        assert expected in written, f"expected {expected} in {written}"


### PR DESCRIPTION
Closes #265

### Problem
`to_player_sav_files()` writes player save filenames from `str(uuid)` (lowercase). Palworld reads player saves by their **uppercase** GUID filename, so on a **case-sensitive filesystem** (any Linux dedicated server) the edited player's `<uid>.sav` / `<uid>_dps.sav` are orphaned and the game loads a **blank character**.

Windows/NTFS is case-insensitive, so it resolves the lowercase name fine — which is why this has gone unnoticed since the writer was introduced (player `.sav` in v0.10.0, `_dps.sav` in v0.12.0).

### Fix
`palworld_save_pal/game/mixins/serialization.py` — uppercase the GUID, matching the convert handler (`player_uuid.hex.upper()`, `convert_handler.py:397`) and the GamePass container paths:

```python
uid = str(uid).replace("-", "").upper()
```

### Test
Adds `TestSaveManagerPlayerSavOutput` asserting `to_player_sav_files` emits uppercase filenames. It fails before the fix (`8c2f1930….sav`) and passes after; the full `tests/game/test_save_manager.py` suite (23 tests) stays green.

### Note
Saves already edited by an affected version still have lowercase files on disk; affected Linux users need to rename those to uppercase once (out of scope for this fix).
