### PR TITLE
fix: prevent orphaned windowless process causing 'Main window failed to start' (#288, #271, #247)

### DIFF
--- a/desktop.py
+++ b/desktop.py
@@ -8,6 +8,7 @@ from urllib.parse import quote
 import sys
 from pathlib import Path
 import multiprocessing
+import threading
 import time
 import webview
 from fastapi import FastAPI, Request, WebSocket, WebSocketDisconnect
@@ -236,7 +237,30 @@ def start_webview(url):
         min_size=(1366, 768),
     )
     app_state.webview_window.events.closed += on_closed
-    webview.start(debug=True, user_agent="pywebview", private_mode=False)
+
+    def window_watchdog():
+        # If the window never reaches shown, every create_file_dialog call
+        # fails with "Main window failed to start" while the server keeps
+        # answering websockets. Better to die and free the port.
+        if not app_state.webview_window.events.shown.wait(60):
+            logger.error(
+                "Webview window did not appear within 60s; "
+                "exiting to avoid an orphaned server process"
+            )
+            remove_lock_file()
+            os._exit(1)
+
+    threading.Thread(target=window_watchdog, daemon=True).start()
+
+    try:
+        webview.start(debug=True, user_agent="pywebview", private_mode=False)
+    except Exception:
+        logger.exception("webview failed to start; shutting down server")
+        app_state.terminate_flag.set()
+        if app_state.server_instance:
+            app_state.server_instance.stop()
+        remove_lock_file()
+        os._exit(1)
 
 
 def on_closed():

--- a/palworld_save_pal/server_thread.py
+++ b/palworld_save_pal/server_thread.py
@@ -9,7 +9,10 @@ logger = create_logger(__name__)
 
 class ServerThread(threading.Thread):
     def __init__(self, app, host, port, dev_mode):
-        super().__init__()
+        # daemon so the process can exit even if the webview never starts;
+        # otherwise a windowless PSP.exe keeps squatting on the port and
+        # every later launch serves its UI from this broken instance
+        super().__init__(daemon=True)
         self.app = app
         self.host = host
         self.port = port


### PR DESCRIPTION
## Summary

Fixes the root cause of `WebViewException: Main window failed to start` when opening the save-file dialog — reported in #288, #271, and #247.

## Root cause

The error is raised by pywebview's `_shown_call` guard: `create_file_dialog` waits up to 20s for the window's `shown` event and raises exactly this message if it never fired. The confusing part is that users hit it **while looking at a perfectly working window**. Here's the chain:

1. Occasionally a launch of PSP.exe fails to ever show its window (e.g. a WebView2 first-run/init hiccup). I reproduced this locally: the process had **no top-level window at all** (verified via `EnumWindows`), while its page had loaded and its server was healthy.
2. That should be fatal, but the uvicorn `ServerThread` is a **non-daemon** thread, so the windowless process survives indefinitely, still bound to port 5174.
3. On the next launch, the new instance's `uvicorn` can't bind the port — the failure is swallowed inside the thread — so the new window silently loads its UI **from the orphaned process's server**. Everything looks and works fine…
4. …until "Select save": the websocket handler runs in the orphan, whose `app_state.webview_window` never reached `shown` → 20s wait → `Main window failed to start`, sent back over the websocket and displayed in the healthy-looking window.

I verified each link on a machine that hit this: sending `select_save` over the websocket to the orphaned process returns the exact reported traceback, and the same message to a healthy instance opens the dialog instantly.

Contributing factor: the single-instance check in `is_instance_running()` can't detect release-build orphans — it looks for `desktop.py` or `palworld-save-pal` in the process cmdline, and the release install path (`PalworldSavePal-vX-...\PSP.exe`) contains neither. (Not changed in this PR, but worth a follow-up.)

## Changes

- `server_thread.py`: `ServerThread` is now a daemon thread, so the process can exit even when `webview.start()` fails.
- `desktop.py`:
  - a watchdog thread exits the process (`os._exit(1)`) if the window hasn't reached `shown` within 60s, freeing the port for the next launch instead of leaving a broken half-alive instance behind;
  - `webview.start()` failures now stop the server, remove the lock file, and exit, instead of orphaning the server.

## Testing

- Reproduced the orphan state and confirmed `select_save` → exact traceback from #288 before the fix.
- With the fix, a launch whose window never appears self-terminates within 60s and releases port 5174; the next launch binds the port itself and the file dialog works.
- Normal startup/shutdown paths unchanged: window shows in ~2s, watchdog no-ops, closing the window still runs `on_closed` cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
