### PR TITLE
Support for resizing storage containers

### DIFF
--- a/palworld_save_pal/game/item_container.py
+++ b/palworld_save_pal/game/item_container.py
@@ -89,7 +89,9 @@ class ItemContainer(BaseModel):
             "%s (%s) with keys %s", self.type.value, self.id, other_container.keys()
         )
         for key, value in other_container.items():
-            if key == "slots":
+            if key == "slot_num" and isinstance(value, int):
+                self.set_slot_count(value)
+            elif key == "slots":
                 new_slots = self._build_new_slots(value)
                 self._update_common_container_slots(new_slots, common_container)
                 self._clean_up_inventory(new_slots)

--- a/ui/src/lib/components/presets/StoragePresets.svelte
+++ b/ui/src/lib/components/presets/StoragePresets.svelte
@@ -15,7 +15,8 @@
 		X,
 		Hash,
 		ChevronsLeftRight,
-		PackagePlus
+		PackagePlus,
+		Expand
 	} from 'lucide-svelte';
 	import { ItemSelectModal, NumberInputModal } from '$components/modals';
 	import * as m from '$i18n/messages';
@@ -235,6 +236,38 @@
 		container.state = EntryState.MODIFIED;
 	}
 
+	async function handleResizeContainer() {
+		if (!container) return;
+		// @ts-ignore
+		const result = await modal.showModal<number>(NumberInputModal, {
+			title: m.available_slots(),
+			value: container.slot_num,
+			min: 0,
+			max: 9999
+		});
+		if (result === null || result === undefined) return;
+
+		const oldSlots = container.slots;
+		let newSlots = [];
+		for (let i = 0; i < result; i++) {
+			const slot = oldSlots.find((s: ItemContainerSlot) => s.slot_index === i);
+			if (!slot) {
+				newSlots.push({
+					static_id: 'None',
+					slot_index: i,
+					count: 0,
+					dynamic_item: undefined
+				});
+			} else {
+				newSlots.push(slot);
+			}
+		}
+		container.slot_num = result;
+		container.slots = newSlots;
+		container.state = EntryState.MODIFIED;
+		onUpdate();
+	}
+
 	function handleClearContainer() {
 		container.slots.forEach((slot: ItemContainerSlot) => {
 			slot.dynamic_item = undefined;
@@ -266,6 +299,12 @@
 			popupLabel={m.set_entity_item_count({ entity: c.container })}
 		>
 			<Hash />
+		</TooltipButton>
+		<TooltipButton
+			onclick={handleResizeContainer}
+			popupLabel={m.available_slots()}
+		>
+			<Expand />
 		</TooltipButton>
 		<TooltipButton
 			onclick={handleClearContainer}

--- a/ui/src/lib/states/saveOperations.svelte.ts
+++ b/ui/src/lib/states/saveOperations.svelte.ts
@@ -88,6 +88,7 @@ export function processGuilds(state: AppState) {
 		}
 		if (guild.guild_chest && guild.guild_chest.state === EntryState.MODIFIED) {
 			guild.guild_chest.state = EntryState.NONE;
+			guild.state = EntryState.MODIFIED;
 		} else if (guildClone.guild_chest) {
 			guildClone.guild_chest = undefined;
 		}

--- a/ui/src/routes/edit/guild/+page.svelte
+++ b/ui/src/routes/edit/guild/+page.svelte
@@ -586,29 +586,6 @@
 		activeTab = 'guildChest';
 	}
 
-	function handleResizeGuildChest(newSlotNum: number) {
-		if (!playerGuild?.guild_chest) return;
-		const chest = playerGuild.guild_chest;
-		const oldSlots = chest.slots;
-		let chestSlots = [];
-		for (let i = 0; i < newSlotNum; i++) {
-			const slot = oldSlots.find((slot) => slot.slot_index === i);
-			if (!slot) {
-				chestSlots.push({
-					static_id: 'None',
-					slot_index: i,
-					count: 0,
-					dynamic_item: undefined
-				});
-			} else {
-				chestSlots.push(slot);
-			}
-		}
-		chest.slot_num = newSlotNum;
-		chest.slots = chestSlots;
-		chest.state = EntryState.MODIFIED;
-	}
-
 	function getItemBackground(rarity: Rarity): string {
 		switch (rarity) {
 			case Rarity.Uncommon:
@@ -1186,14 +1163,6 @@
 										src={guildChestIcon}
 										alt="Storage Container Icon"
 										class="ml-8 max-h-48 max-w-48 2xl:max-h-64 2xl:max-w-64"
-									/>
-									<Input
-										type="number"
-										label={m.available_slots()}
-										value={playerGuild.guild_chest.slot_num}
-										min={0}
-										max={9999}
-										onValueChange={(v: number) => handleResizeGuildChest(v)}
 									/>
 									<StoragePresets
 										container={playerGuild.guild_chest}

--- a/ui/src/routes/edit/guild/+page.svelte
+++ b/ui/src/routes/edit/guild/+page.svelte
@@ -586,6 +586,29 @@
 		activeTab = 'guildChest';
 	}
 
+	function handleResizeGuildChest(newSlotNum: number) {
+		if (!playerGuild?.guild_chest) return;
+		const chest = playerGuild.guild_chest;
+		const oldSlots = chest.slots;
+		let chestSlots = [];
+		for (let i = 0; i < newSlotNum; i++) {
+			const slot = oldSlots.find((slot) => slot.slot_index === i);
+			if (!slot) {
+				chestSlots.push({
+					static_id: 'None',
+					slot_index: i,
+					count: 0,
+					dynamic_item: undefined
+				});
+			} else {
+				chestSlots.push(slot);
+			}
+		}
+		chest.slot_num = newSlotNum;
+		chest.slots = chestSlots;
+		chest.state = EntryState.MODIFIED;
+	}
+
 	function getItemBackground(rarity: Rarity): string {
 		switch (rarity) {
 			case Rarity.Uncommon:
@@ -1163,6 +1186,14 @@
 										src={guildChestIcon}
 										alt="Storage Container Icon"
 										class="ml-8 max-h-48 max-w-48 2xl:max-h-64 2xl:max-w-64"
+									/>
+									<Input
+										type="number"
+										label={m.available_slots()}
+										value={playerGuild.guild_chest.slot_num}
+										min={0}
+										max={9999}
+										onValueChange={(v: number) => handleResizeGuildChest(v)}
 									/>
 									<StoragePresets
 										container={playerGuild.guild_chest}


### PR DESCRIPTION
Adds the ability to change the slot count of any storage container (including guild chests) directly from the toolbar in the editor UI.

Possible uses:
- Increase guild chest size without having to recreate the guild - mods (like [this](https://www.nexusmods.com/palworld/mods/3434)) only work for new guilds
- Disable your guild chest (by setting the size to 0 slots) for extra challenge
- Make your favorite wooden chest bigger

Includes a bugfix for changes to guild chests being silently dropped on save: when a guild chest was modified, the parent guild was not marked as `MODIFIED`.
 